### PR TITLE
Added Updates to the Conformance Testing Process

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -145,7 +145,7 @@ for details)
 <li> The Conformance Testing process is <strong>periodically reviewed, updated, and scope expanded</strong> (see
 [[#out-of-scope]]) to reflect changes in the organization's standards and requirements, as well as feedback received
 from members of the network.
-<li> <strong>Process when the testing Partner deosn't have a Solution yet or has "Data Recipient Only" solution</strong>
+<li> <strong>Process when the testing Partner doesn't have a Solution yet or has a "Data Recipient Only" solution</strong>
 There are situations where an Organization chooses to only implement "Data Recipient only" capability in the immediate term due to the business model or product constraints, hence PACT still encourages these Organizations to participate in the PACT Conformance Testing process and to be onboarded to the PACT Catalog. Below are the proposed changes to address this-  
 
 

--- a/index.bs
+++ b/index.bs
@@ -210,7 +210,7 @@ it. Please Refer below -
 : What are the pre-requisites for participating in the Connectathons?
 :: The main pre-requisites for participating in the Connectathons is that you have a Solution (fully ready or partially
     ready) that follows Technical Specification V1 or V2. In the cases when your organization doesn't have a Solution yet Or has a Solution but it offers only Data Recipient capabilities (i.e. your Solution doesn't provide PCF data as Data Owner per PACT Technical Specifications)
-  then your Organization can still participate in the Connectathon and Conformance Testing process, but in these cases your Solution will not be onboarded to the Catalog, but your Organization will be onboarded as "Collaborator" in the PACT Catalog. Please refer "[this documentation](https://wbcsd.sharepoint.com/:w:/s/ClimateEnergy/ERLYPpzyLztMpiUktDXk_ZcB_syU_XSN25gL56ZW-QdZLQ?e=vw3tea)" for more detailed overview of the process in such scenarios.
+  then your Organization can still participate in the Connectathon and Conformance Testing process, but in these cases your Solution will not be onboarded to the Catalog, but your Organization will be onboarded as "Collaborator" in the PACT Catalog. Please refer to "[this documentation](https://wbcsd.sharepoint.com/:w:/s/ClimateEnergy/ERLYPpzyLztMpiUktDXk_ZcB_syU_XSN25gL56ZW-QdZLQ?e=vw3tea)" for more detailed overview of the process in such scenarios.
 
 : Is there a limit on the Testing Partners an Organizations can conduct Conformance Testing with during the
     Connectathons?

--- a/index.bs
+++ b/index.bs
@@ -146,7 +146,7 @@ for details)
 [[#out-of-scope]]) to reflect changes in the organization's standards and requirements, as well as feedback received
 from members of the network.
 <li> <strong>Process when the testing Partner doesn't have a Solution yet or has a "Data Recipient Only" solution</strong>
-There are situations where an Organization chooses to only implement "Data Recipient only" capability in the immediate term due to the business model or product constraints, hence PACT still encourages these Organizations to participate in the PACT Conformance Testing process and to be onboarded to the PACT Catalog. Below are the proposed changes to address this-  
+There are situations where an Organization chooses to implement "Data Recipient only" capability in the immediate term due to business model or product constraints. PACT still encourages these Organizations to participate in the PACT Conformance Testing process and to be onboarded to the PACT Catalog. Below are the proposed changes to address this-  
 
 
 For both these scenarios, the concerned Organization can still participate in the Connectathon and Conformance Testing and test another Organization’s solution by participating in the data exchange as recipient and validate the conformance of the other solution based on the PACT standards / specification.  

--- a/index.bs
+++ b/index.bs
@@ -152,7 +152,7 @@ There are situations where an Organization chooses to implement "Data Recipient 
 For both these scenarios, the concerned Organization can still participate in the Connectathon and Conformance Testing and test another Organization’s solution by participating in the data exchange as recipient and validate the conformance of the other solution based on the PACT standards / specification.  
 The other Organization can add the Conformance Test Result from this testing to the Catalog by following the Scenario 2 as depicted in [these instructions](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_TEST.md#2-fill-in-the-conformance-test-details) 
 
-<u>Note:</u>For both the above scenarios – The concerned Organization will still need to submit a Pull request in the PACT Catalog repo to add their Organization as a” User”. Please follow [these instructions](https://github.com/wbcsd/pact-catalog/blob/main/README.md#3-create-a-new-user-in-the-users-directory) to do so.  
+<u>Note:</u>For both the above scenarios – The concerned Organization will still need to submit a Pull request in the PACT Catalog repo to add their Organization as a ”User”. Please follow [these instructions](https://github.com/wbcsd/pact-catalog/blob/main/README.md#3-create-a-new-user-in-the-users-directory) to do so.  
 
 The concerned Organization as per the above scenarios will appear in the Catalog under the “Collaborators” page, even though their Solution may not be in the PACT Catalog
 

--- a/index.bs
+++ b/index.bs
@@ -146,8 +146,7 @@ for details)
 [[#out-of-scope]]) to reflect changes in the organization's standards and requirements, as well as feedback received
 from members of the network.
 <li> <strong>Process when the testing Partner doesn't have a Solution yet or has a "Data Recipient Only" solution</strong>
-There are situations where an Organization chooses to implement "Data Recipient only" capability in the immediate term due to business model or product constraints. PACT still encourages these Organizations to participate in the PACT Conformance Testing process and to be onboarded to the PACT Catalog. Below are the proposed changes to address this-  
-
+There are situations where an Organization chooses to implement "Data Recipient only" capability in the immediate term due to business model or product constraints. PACT still encourages these Organizations to participate in the PACT Conformance Testing process and to be onboarded to the PACT Catalog.
 
 For both these scenarios, the concerned Organization can still participate in the Connectathon and Conformance Testing and test another Organization’s solution by participating in the data exchange as recipient and validate the conformance of the other solution based on the PACT standards / specification.  
 The other Organization can add the Conformance Test Result from this testing to the Catalog by following the Scenario 2 as depicted in [these instructions](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_TEST.md#2-fill-in-the-conformance-test-details) 

--- a/index.bs
+++ b/index.bs
@@ -145,6 +145,16 @@ for details)
 <li> The Conformance Testing process is <strong>periodically reviewed, updated, and scope expanded</strong> (see
 [[#out-of-scope]]) to reflect changes in the organization's standards and requirements, as well as feedback received
 from members of the network.
+<li> <strong>Process when the testing Partner deosn't have a Solution yet or has "Data Recipient Only" solution</strong>
+There are situations where an Organization chooses to only implement "Data Recipient only" capability in the immediate term due to the business model or product constraints, hence PACT still encourages these Organizations to participate in the PACT Conformance Testing process and to be onboarded to the PACT Catalog. Below are the proposed changes to address this-  
+
+
+For both these scenarios, the concerned Organization can still participate in the Connectathon and Conformance Testing and test another Organization’s solution by participating in the data exchange as recipient and validate the conformance of the other solution based on the PACT standards / specification.  
+The other Organization can add the Conformance Test Result from this testing to the Catalog by following the Scenario 2 as depicted in [these instructions](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_TEST.md#2-fill-in-the-conformance-test-details) 
+
+<u>Note:</u>For both the above scenarios – The concerned Organization will still need to submit a Pull request in the PACT Catalog repo to add their Organization as a” User”. Please follow [these instructions](https://github.com/wbcsd/pact-catalog/blob/main/README.md#3-create-a-new-user-in-the-users-directory) to do so.  
+
+The concerned Organization as per the above scenarios will appear in the Catalog under the “Collaborators” page, even though their Solution may not be in the PACT Catalog
 
 ## PACT Conformance Test criteria (Checklist) ## {#checklist}
 Recommendation from WBCSD to be used as a reference for the Bilateral Conformance Testing criteria for Technical
@@ -157,7 +167,7 @@ Please Note - This is a template created with the intention to guide you on what
 but we also encourage you to add any other test cases you feel are necessary for your test coverage.
 
 ## PACT Conformance Test - Sample Payloads
-Access the sample payloads for the Pathfinder API endpoints [here](https://documenter.getpostman.com/view/27574443/2s93mASyuH).
+Access the sample payloads for the Pathfinder API demo endpoints [here](https://documenter.getpostman.com/view/27574443/2s93mASyuH).
 
 
 # Onboarding Solutions to the PACT Online Catalog # {#onboarding}
@@ -175,17 +185,17 @@ it. Please Refer below -
 ## Process to Submit a Solution in Online Catalog ## {#submit-solution-process}
 
 <ol>
-  <li> Navigate to the “[Contribute](https://pact-catalog.sine.dev/contribute)” section
+  <li> Navigate to the “[Contribute](https://catalog.carbon-transparency.com/contribute)” section
   <li> Click the first “Go to GitHub”  button under the “Developing Solutions?” option
     <ul>
       <li> You will be taken directly to the [WBCSD PACT Online Catalog repo](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_SOLUTION.md).
       <li> Follow the process as described in the CONTRIB_SOLUTION.md to Submit a Pull Request (PR) for your Solution
     </ul>
   <li> Once the Pull Request is submitted (above step), the Pull Request will be reviewed for completeness. If all
-  details are filled out correctly, the PR will be merged and the Conforming Solution will appear under the “[Solutions](https://pact-catalog.sine.dev/solutions)"
+  details are filled out correctly, the PR will be merged and the Conforming Solution will appear under the “[Solutions](https://catalog.carbon-transparency.com/solutions)"
   page on the Online Catalog
-  <li> After clicking a particular “Conformant Solution”, you will be taken to its Details page ([example](https://pact-catalog.sine.dev/solutions/example-solution/0.0.0))
-  <li> You can review the details of all your Conformance Tests under the “Conformance” tab ([example](https://pact-catalog.sine.dev/solutions/example-solution/0.0.0?activeTab=conformance))
+  <li> After clicking a particular “Conformant Solution”, you will be taken to its Details page 
+  <li> You can review the details of all your Conformance Tests under the “Conformance” tab 
 </ol>
 
 # FAQs # {#faqs}
@@ -199,7 +209,8 @@ it. Please Refer below -
 
 : What are the pre-requisites for participating in the Connectathons?
 :: The main pre-requisites for participating in the Connectathons is that you have a Solution (fully ready or partially
-    ready) that follows Technical Specification V1 or V2
+    ready) that follows Technical Specification V1 or V2. In the cases when your organization doesn't have a Solution yet Or has a Solution but it offers only Data Recipient capabilities (i.e. your Solution doesn't provide PCF data as Data Owner per PACT Technical Specifications)
+  then your Organization can still participate in the Connectathon and Conformance Testing process, but in these cases your Solution will not be onboarded to the Catalog, but your Organization will be onboarded as "Collaborator" in the PACT Catalog. Please refer "[this documentation](https://wbcsd.sharepoint.com/:w:/s/ClimateEnergy/ERLYPpzyLztMpiUktDXk_ZcB_syU_XSN25gL56ZW-QdZLQ?e=vw3tea)" for more detailed overview of the process in such scenarios.
 
 : Is there a limit on the Testing Partners an Organizations can conduct Conformance Testing with during the
     Connectathons?
@@ -237,5 +248,10 @@ it. Please Refer below -
 
   <li> [Pathfinder Technical Specifications Version 1.0.1](https://wbcsd.github.io/data-exchange-protocol/)
   <li> [Pathfinder Technical Specifications Version 2.0.1](https://wbcsd.github.io/data-exchange-protocol/v2/)
-  <li> [PACT Online Catalog](https://pact-catalog.sine.dev)
-  <li> [Instructions on how to publish Conformance Test Results to the PACT Online Catalog](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_TEST.md)
+  <li> [PACT Online Catalog](https://catalog.carbon-transparency.com/)
+  <li> [Instructions on how to add a Solution to the PACT Online Catalog](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_SOLUTION.md)
+  <li> [Instructions on how to add Conformance Test Results to the PACT Online Catalog](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_TEST.md)
+  <li> [Instructions on how to add Data Model Extension to the PACT Online Catalog](https://github.com/wbcsd/pact-catalog/blob/main/CONTRIB_EXTENSION.md)
+  <li> [Sample PACT Conformance Test Cases Template](https://github.com/wbcsd/pact-conformance-testing/blob/main/PACT%20Conformance%20Testing%20-%20Test%20Cases.md)
+  <li> [Sample payloads for the Pathfinder API demo endpoints](https://documenter.getpostman.com/view/27574443/2s93mASyuH)
+  


### PR DESCRIPTION
- Updated the Conformance process to add these scenarios - 

- If an Org Has a Solution which is a “Data Recipient Only” Solution and hence doesn’t offer the capability to provide PCF data as a Source 

- if an Org doesn’t have a Solution yet but still would like to participate in the PACT Conformance Testing / Connectathon  
- Corrected the links to PACT Catalog
- Updated the FAQs
- Updated Resources list