### PR TITLE
Feature/update requirements

### DIFF
--- a/checklist.bs
+++ b/checklist.bs
@@ -140,8 +140,19 @@ No additional request parameters, such as `limit` or `filter`, must be defined.
 
 ### Expected Response ### {#tc003-response}
 
-The test target host system must respond with 200 OK and a JSON body containing the list of all
-available PCFs, as specified in [[DXP#api-action-list-response]].
+Depending on whether PCFs can be delivered or not, the test target host system should respond with 
+one of the following answers:
+
+- 200 OK and a JSON body containing the list of all
+    available PCFs, as specified in [[DXP#api-action-list-response]], or
+
+- 202 ACCEPTED and a JSON body containing the list of some
+    available PCFs, as specified in [[DXP#api-action-list-response]], or
+
+- 400 BAD REQUEST and a JSON body containing an error, as specified in
+    [[DXP#api-action-auth-response]] To indicate that Action events should 
+    be used to retrieve PCF values.
+    In this case, the testing party must execute the test case [[#tc012]].
 
 ## Test Case 004: Get Limited List of Footprints ## {#tc004}
 
@@ -157,11 +168,19 @@ system with the **limit** parameter, a **valid access token** and the syntax spe
 ### Expected Response ### {#tc004-response}
 
 The test target host system must respond with
-1. either an HTTP status code `200` "OK" with a response body containing a list of PCFs with a length equal to or
-    smaller than the limit set in the request, as specified in [[DXP#api-action-list-response]].
-    Unless the total number of available PCFs is equal to or smaller than the limit set in the request,
-    the test target host system must return a `Link` header
-2. or an HTTP status code `202` and an empty body
+- 200 OK and a JSON body containing the list of all
+    available PCFs, as specified in [[DXP#api-action-list-response]]
+    Unless the total number of available PCFs is equal to or smaller 
+    than the limit set in the request, the test target host system 
+    must return a `Link` header, or
+
+- 202 ACCEPTED and a JSON body containing the list of some
+    available PCFs, as specified in [[DXP#api-action-list-response]], or
+
+- 400 BAD REQUEST and a JSON body containing an error, as specified in
+    [[DXP#api-action-list-response]]] To indicate that Action events should 
+    be used to retrieve PCF values.
+    In this case, the testing party must execute the test case [[#tc012]].
 
 Note: For testing purposes it is recommended to set the limit to a small number (e.g., 2) to ensure
 that pagination is tested.
@@ -169,7 +188,7 @@ that pagination is tested.
 ## Test Case 005: Pagination link implementation of Action ListFootprints ## {#tc005}
 
 Note: This test presupposes the completion of [[#tc004]] and uses the `link` returned in the header.
-If [[#tc004]] fails, this test can be skipped.
+If [[#tc004]] didn't return HTTP-200 and a pagination link, this test can be skipped.
 
 Tests the target host system's ability to return PCFs when the same pagination link, returned through the `link` header,
 is called multiple times.
@@ -239,6 +258,15 @@ host system with a **valid access token** and the syntax specified in
 The test target host system must respond with 200 OK and a JSON body containing the PCF with the
 requested `pfId`, as specified in [[DXP#api-action-get-response]].
 
+The test target host system must respond with
+- 200 OK and a JSON body containing the PCF with the
+    requested `pfId`, as specified in [[DXP#api-action-get-response]], or
+
+- 400 BAD REQUEST and a JSON body containing an error, as specified in
+    [[DXP#api-action-get-response]] To indicate that Action events should 
+    be used to retrieve PCF values.
+    In this case, the testing party must execute the test case [[#tc012]].
+
 ## Test Case 009: Attempt GetFootprint with Expired Token ## {#tc009}
 
 Tests the target host system's ability to reject a GetFootprint request with an expired access token
@@ -289,6 +317,14 @@ syntax specified in [[DXP#api-action-get-request]].
 The test target host system should respond with a 404 Not Found and a JSON body containing the error
 code `NoSuchFootprint`, as specified in [[DXP#api-error-responses]].
 
+The test target host system must respond with
+- 404 NOT FOUND and a JSON body containing the error code `NoSuchFootprint`,
+    as specified in [[DXP#api-error-responses]], or
+
+- 400 BAD REQUEST and a JSON body containing an error, as specified in
+    [[DXP#api-action-get-response]] To indicate that Action events should 
+    be used to retrieve PCF values.
+
 ## Test Case 012: Asynchronous PCF Request ## {#tc012}
 
 Tests the target host system's ability to receive an asynchronous PCF request.
@@ -307,9 +343,7 @@ The test target host system must respond with 200 OK.
 Tests the target host system's ability to respond to an asynchronous PCF request.
 
 Note: For this test case, the data owner is the test target host system and the data recipient is
-the testing party. Accordingly, the latter must be conformant with [[DXP#api-action-events]] and
-behave in accordance if the functionality is not implemented. This test assumes the completion
-of [[#tc014]] and should be skipped if it failed.
+the testing party. Accordingly, the latter must be conformant with [[DXP#api-action-events]].
 
 ### Request ### {#tc013-request}
 

--- a/checklist.bs
+++ b/checklist.bs
@@ -109,7 +109,7 @@ must respond with either
     [[DXP#api-action-auth-response]], or
 
 - 400 Bad Request and a JSON body containing an error, as specified in
-    [[DXP#api-action-auth-response]]. In this case, the testing party must execute the test case
+    [[DXP#api-error-responses]]. In this case, the testing party must execute the test case
     [[#tc016]].
 
 ## Test Case 002: Authentication with invalid credentials against default endpoint ## {#tc002}
@@ -150,7 +150,7 @@ one of the following answers:
     available PCFs, as specified in [[DXP#api-action-list-response]], or
 
 - 400 BAD REQUEST and a JSON body containing an error, as specified in
-    [[DXP#api-action-auth-response]] To indicate that Action events should 
+    [[DXP#api-error-responses]] To indicate that Action events should 
     be used to retrieve PCF values.
     In this case, the testing party must execute the test case [[#tc012]].
 
@@ -178,7 +178,7 @@ The test target host system must respond with
     available PCFs, as specified in [[DXP#api-action-list-response]], or
 
 - 400 BAD REQUEST and a JSON body containing an error, as specified in
-    [[DXP#api-action-list-response]]] To indicate that Action events should 
+    [[DXP#api-error-responses]] To indicate that Action events should 
     be used to retrieve PCF values.
     In this case, the testing party must execute the test case [[#tc012]].
 
@@ -263,7 +263,7 @@ The test target host system must respond with
     requested `pfId`, as specified in [[DXP#api-action-get-response]], or
 
 - 400 BAD REQUEST and a JSON body containing an error, as specified in
-    [[DXP#api-action-get-response]] To indicate that Action events should 
+    [[DXP#api-error-responses]] To indicate that Action events should 
     be used to retrieve PCF values.
     In this case, the testing party must execute the test case [[#tc012]].
 
@@ -322,7 +322,7 @@ The test target host system must respond with
     as specified in [[DXP#api-error-responses]], or
 
 - 400 BAD REQUEST and a JSON body containing an error, as specified in
-    [[DXP#api-action-get-response]] To indicate that Action events should 
+    [[DXP#api-error-responses]] To indicate that Action events should 
     be used to retrieve PCF values.
 
 ## Test Case 012: Asynchronous PCF Request ## {#tc012}

--- a/checklist.bs
+++ b/checklist.bs
@@ -289,59 +289,20 @@ syntax specified in [[DXP#api-action-get-request]].
 The test target host system should respond with a 404 Not Found and a JSON body containing the error
 code `NoSuchFootprint`, as specified in [[DXP#api-error-responses]].
 
-## Test Case 012: Receive Notification of PCF Update ## {#tc012}
+## Test Case 012: Asynchronous PCF Request ## {#tc012}
 
-Tests the target host system's ability to be notified of a PCF update.
+Tests the target host system's ability to receive an asynchronous PCF request.
 
 ### Request ### {#tc012-request}
 
 A POST request must be sent to the test target host system's `/2/events` endpoint with the syntax
-specified in [[DXP#api-action-events-case-1]].
+specified in [[DXP#api-action-events-case-2-request]].
 
 ### Expected Response ### {#tc012-response}
 
-The test target host system must respond with 200 OK and an empty body.
-
-If the test target host system calls the GetFootprint action with the `pfId` included in the
-notification, the corresponding PCF must be returned.
-
-## Test Case 013: Notify of PCF Update ## {#tc013}
-
-Tests the target host system's ability to notify a data recipient of a PCF update.
-
-Note: For this test case, the data owner is the test target host system and the data recipient is
-the testing party. Accordingly, the latter must be conformant with [[DXP#api-action-events]] and
-behave in accordance if the functionality is not implemented.
-
-### Request ### {#tc013-request}
-
-The test target host system must authenticate with the testing party (performing the customary
-[[DXP#api-auth|Authentication Flow]] and obtain an access token.
-
-The test target host system must send a POST request to the testing party's `/2/events` endpoint
-with a valid access token and the syntax specified in [[DXP#api-action-events-case-1]].
-
-### Expected Response ### {#tc013-response}
-
-If the testing party has implemented the Events functionality, it should respond with 200 OK and an empty body.
-
-Otherwise, it should respond with 400 Bad Request and a JSON body containing the error response
-`NotImplemented`, as specified in [[DXP#api-error-responses]].
-
-## Test Case 014: Asynchronous PCF Request ## {#tc014}
-
-Tests the target host system's ability to receive an asynchronous PCF request.
-
-### Request ### {#tc014-request}
-
-A POST request must be sent to the test target host system's `/2/events` endpoint with the syntax
-specified in [[DXP#api-action-events-case-2-request]].
-
-### Expected Response ### {#tc014-response}
-
 The test target host system must respond with 200 OK.
 
-## Test Case 015: Respond to Asynchronous PCF Request ## {#tc015}
+## Test Case 013: Respond to Asynchronous PCF Request ## {#tc013}
 
 Tests the target host system's ability to respond to an asynchronous PCF request.
 
@@ -350,7 +311,7 @@ the testing party. Accordingly, the latter must be conformant with [[DXP#api-act
 behave in accordance if the functionality is not implemented. This test assumes the completion
 of [[#tc014]] and should be skipped if it failed.
 
-### Request ### {#tc015-request}
+### Request ### {#tc013-request}
 
 The test target host system must authenticate with the testing party (performing the customary
 [[DXP#api-auth|Authentication Flow]]) and obtain an access token.
@@ -358,7 +319,7 @@ The test target host system must authenticate with the testing party (performing
 The test target host system must send a POST request to the testing party's `/2/events` endpoint
 with a valid access token and the syntax specified in [[DXP#api-action-events-case-2-response]].
 
-### Expected Response ### {#tc015-response}
+### Expected Response ### {#tc013-response}
 
 If the testing party has implemented the Events functionality, it should respond with 200 OK and an empty body.
 
@@ -366,6 +327,45 @@ Otherwise, it should respond with 400 Bad Request and a JSON body containing the
 `NotImplemented`, as specified in [[DXP#api-error-responses]].
 
 # Optional Test Cases # {#optional-tests}
+
+## Test Case 014: Receive Notification of PCF Update ## {#tc014}
+
+Tests the target host system's ability to be notified of a PCF update.
+
+### Request ### {#tc014-request}
+
+A POST request must be sent to the test target host system's `/2/events` endpoint with the syntax
+specified in [[DXP#api-action-events-case-1]].
+
+### Expected Response ### {#tc014-response}
+
+The test target host system must respond with 200 OK and an empty body.
+
+If the test target host system calls the GetFootprint action with the `pfId` included in the
+notification, the corresponding PCF must be returned.
+
+## Test Case 015: Notify of PCF Update ## {#tc015}
+
+Tests the target host system's ability to notify a data recipient of a PCF update.
+
+Note: For this test case, the data owner is the test target host system and the data recipient is
+the testing party. Accordingly, the latter must be conformant with [[DXP#api-action-events]] and
+behave in accordance if the functionality is not implemented.
+
+### Request ### {#tc015-request}
+
+The test target host system must authenticate with the testing party (performing the customary
+[[DXP#api-auth|Authentication Flow]] and obtain an access token.
+
+The test target host system must send a POST request to the testing party's `/2/events` endpoint
+with a valid access token and the syntax specified in [[DXP#api-action-events-case-1]].
+
+### Expected Response ### {#tc015-response}
+
+If the testing party has implemented the Events functionality, it should respond with 200 OK and an empty body.
+
+Otherwise, it should respond with 400 Bad Request and a JSON body containing the error response
+`NotImplemented`, as specified in [[DXP#api-error-responses]].
 
 ## Test Case 016: OpenId Connect-based Authentication Flow ## {#tc016}
 


### PR DESCRIPTION
As discussed we adapted the expected results of some of the tests and move tests dealing with not mandatory feature into to optional section.

What was changed in detail:

These should test for "valid answer" not for success (eg. HTTP-400 is a valid answer, eg. "redirect" to asyc API):
Test Case 003: Get All Footprints
Test Case 004: Get Limited List of Footprints
Test Case 008: Get Footprint
Test Case 011: Attempt GetFootprint with Non-Existent PfId

These tests should be optional as the feature they test is optional:
Test Case 012: Receive Notification of PCF Update
Test Case 013: Notify of PCF Update

In addition we had an internal discussion regarding the definiition of an "invalid token". This should be described in more detail (a "broken" token missing half of the data, a token with the wrong scope, ...). As based on the definition we should expect an HTTP-403 (Forbidden) or a HTTP-401 (Unauthorized) - see also: https://www.permit.io/blog/401-vs-403-error-whats-the-difference . This should be defined clearer in another PR.